### PR TITLE
use from_utf8_lossy to avoid server error on invalid text data

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -180,6 +180,16 @@ speculate! {
         assert_eq!(response.status(), Status::Ok);
         assert_eq!(response.body_bytes(), Some(contents));
     }
+
+    it "can cope with invalid unicode data" {
+        let invalid_data = unsafe {
+            String::from_utf8_unchecked(b"Hello \xF0\x90\x80World".to_vec())
+        };
+        let id = insert_data(&client, &invalid_data, "/");
+    
+        let response = get_data(&client, id);
+        assert_eq!(response.status(), Status::Ok);
+    }
 }
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");
@@ -414,7 +424,7 @@ fn get<'r>(
 
     let mut map = json!({
         "is_created": "true",
-        "pastebin_code": std::str::from_utf8(entry.data().unwrap()).unwrap(),
+        "pastebin_code": String::from_utf8_lossy(entry.data().unwrap()),
         "pastebin_id": id,
         "pastebin_language": selected_lang,
         "version": VERSION,


### PR DESCRIPTION
When viewing a page that contains invalid UTF-8, I get the following error in the log file:
```
thread '<unnamed>' panicked at 'called `Result::unwrap()` on an `Err` value: Utf8Error { valid_up_to: 3077, error_len: Some(1) }', src/main.rs:417:69
```
My fix replaces invalid data with the �, see documentation here: https://doc.rust-lang.org/std/string/struct.String.html#method.from_utf8_lossy